### PR TITLE
[FIX] Fix broken import (bounds)

### DIFF
--- a/cassetta/core/typing.py
+++ b/cassetta/core/typing.py
@@ -5,7 +5,6 @@ __all__ = [
     'OneOrSeveral',
     'DeviceType',
     'DataType',
-    'BoundType',
     'InterpolationType',
     'ActivationType',
     'NormType',
@@ -19,7 +18,6 @@ import torch
 import numpy as np
 from torch.nn import Module
 from torch.optim import Optimizer
-from bounds.types import BoundLike as BoundType
 from typing import (
     Union, Optional, Sequence, Literal, Type, TypeVar
 )


### PR DESCRIPTION
There was a broken import in cassetta/core/typing.py which attempted to import from a module (bounds) that does not exist. This fixes the import by deleting it.